### PR TITLE
feat(bpf): replace perf event arrays with ring buffer for event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ bpfsnitch is an open-source, real-time monitoring tool for Linux systems and Kub
 
 ## Prerequisites
 
-- **Linux Kernel with eBPF Support**: bpfsnitch requires a Linux kernel version that supports eBPF (version 4.4 or higher recommended).
+- **Linux Kernel with eBPF Support**: bpfsnitch requires a Linux kernel version that supports eBPF (version 5.8 or higher recommended).
 - **eBPF Libraries**: Ensure that `libbpf` and related dependencies are installed.
 - **Prometheus**: For metrics scraping and monitoring.
-- **Container Runtime**: Supports Docker and Kubernetes environments.
+- **Container Runtime**: Supports Docker and Containerd Kubernetes environments.
 
 ---
 

--- a/bpf/core.h
+++ b/bpf/core.h
@@ -18,20 +18,11 @@ struct {
 
 struct syscall_event {
   long syscall_nr;
-  u64 ts;
   u64 cgroup_id;
   u64 pid;
 };
 
-struct {
-  __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-  __uint(key_size, sizeof(__u32));
-  __uint(value_size, sizeof(__u32));
-  __uint(max_entries, 8192);
-} syscall_events SEC(".maps");
-
 struct network_event {
-  u64 ts;
   u64 pid;
   u64 cgroup_id;
   u64 size;
@@ -47,8 +38,11 @@ struct network_event {
 };
 
 struct {
-  __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-  __uint(key_size, sizeof(__u32));
-  __uint(value_size, sizeof(__u32));
-  __uint(max_entries, 8192);
-} network_events SEC(".maps");
+  __uint(type, BPF_MAP_TYPE_RINGBUF);
+  __uint(max_entries, 1<<25); // 32MB
+} network_events_rb SEC(".maps");
+
+struct {
+  __uint(type, BPF_MAP_TYPE_RINGBUF);
+  __uint(max_entries, 1<<24); // 16MB
+} syscall_events_rb SEC(".maps");

--- a/bpf/kprobe/trace_tcp.c
+++ b/bpf/kprobe/trace_tcp.c
@@ -51,7 +51,7 @@ int trace_tcp_recvmsg(struct tcp_recvmsg_args *ctx) {
   e.direction = 0;
   e.protocol = 6;
 
-  bpf_ringbuf_output(&network_events_rb, &e, sizeof(e), BPF_RB_NO_WAKEUP);
+  bpf_ringbuf_output(&network_events_rb, &e, sizeof(e), BPF_RB_FORCE_WAKEUP);
   return 0;
 }
 
@@ -102,6 +102,6 @@ int trace_tcp_sendmsg(struct tcp_sendmsg_args *ctx) {
   e.direction = 1;
   e.protocol = 6;
 
-  bpf_ringbuf_output(&network_events_rb, &e, sizeof(e), BPF_RB_NO_WAKEUP);
+  bpf_ringbuf_output(&network_events_rb, &e, sizeof(e), BPF_RB_FORCE_WAKEUP);
   return 0;
 }

--- a/bpf/kprobe/trace_tcp.c
+++ b/bpf/kprobe/trace_tcp.c
@@ -11,7 +11,6 @@ struct tcp_recvmsg_args {
 
 SEC("kprobe/tcp_recvmsg")
 int trace_tcp_recvmsg(struct tcp_recvmsg_args *ctx) {
-  u64 ts = bpf_ktime_get_ns();
   u64 cgroup_id = bpf_get_current_cgroup_id();
   u32 pid = bpf_get_current_pid_tgid() >> 32;
 
@@ -42,7 +41,6 @@ int trace_tcp_recvmsg(struct tcp_recvmsg_args *ctx) {
   }
 
   struct network_event e = {};
-  e.ts = ts;
   e.pid = pid;
   e.cgroup_id = cgroup_id;
   e.saddr = saddr;
@@ -53,7 +51,7 @@ int trace_tcp_recvmsg(struct tcp_recvmsg_args *ctx) {
   e.direction = 0;
   e.protocol = 6;
 
-  bpf_perf_event_output(ctx, &network_events, BPF_F_CURRENT_CPU, &e, sizeof(e));
+  bpf_ringbuf_output(&network_events_rb, &e, sizeof(e), BPF_RB_NO_WAKEUP);
   return 0;
 }
 
@@ -65,7 +63,6 @@ struct tcp_sendmsg_args {
 
 SEC("kprobe/tcp_sendmsg")
 int trace_tcp_sendmsg(struct tcp_sendmsg_args *ctx) {
-  u64 ts = bpf_ktime_get_ns();
   u64 cgroup_id = bpf_get_current_cgroup_id();
   u32 pid = bpf_get_current_pid_tgid() >> 32;
   struct sock *sk = ctx->sk;
@@ -95,7 +92,6 @@ int trace_tcp_sendmsg(struct tcp_sendmsg_args *ctx) {
   }
 
   struct network_event e = {};
-  e.ts = ts;
   e.pid = pid;
   e.cgroup_id = cgroup_id;
   e.saddr = saddr;
@@ -106,6 +102,6 @@ int trace_tcp_sendmsg(struct tcp_sendmsg_args *ctx) {
   e.direction = 1;
   e.protocol = 6;
 
-  bpf_perf_event_output(ctx, &network_events, BPF_F_CURRENT_CPU, &e, sizeof(e));
+  bpf_ringbuf_output(&network_events_rb, &e, sizeof(e), BPF_RB_NO_WAKEUP);
   return 0;
 }

--- a/bpf/kprobe/trace_udp.c
+++ b/bpf/kprobe/trace_udp.c
@@ -10,7 +10,6 @@ struct udp_recvmsg_args {
 
 SEC("kprobe/udp_recvmsg")
 int trace_udp_recvmsg(struct udp_recvmsg_args *ctx) {
-  u64 ts = bpf_ktime_get_ns();
   u64 cgroup_id = bpf_get_current_cgroup_id();
   u32 pid = bpf_get_current_pid_tgid() >> 32;
 
@@ -41,7 +40,6 @@ int trace_udp_recvmsg(struct udp_recvmsg_args *ctx) {
   }
   
   struct network_event e = {};
-  e.ts = ts;
   e.pid = pid;
   e.cgroup_id = cgroup_id;
   e.saddr = saddr;
@@ -52,7 +50,7 @@ int trace_udp_recvmsg(struct udp_recvmsg_args *ctx) {
   e.direction = 0;
   e.protocol = 17;
 
-  bpf_perf_event_output(ctx, &network_events, BPF_F_CURRENT_CPU, &e, sizeof(e));
+  bpf_ringbuf_output(&network_events_rb, &e, sizeof(e), BPF_RB_NO_WAKEUP);
   return 0;
 }
 
@@ -64,7 +62,6 @@ struct udp_sendmsg_args {
 
 SEC("kprobe/udp_sendmsg")
 int trace_udp_sendmsg(struct udp_sendmsg_args *ctx) {
-  u64 ts = bpf_ktime_get_ns();
   u64 cgroup_id = bpf_get_current_cgroup_id();
   u32 pid = bpf_get_current_pid_tgid() >> 32;
 
@@ -95,8 +92,6 @@ int trace_udp_sendmsg(struct udp_sendmsg_args *ctx) {
   }
 
   struct network_event e = {};
-
-  e.ts = ts;
   e.direction = 1;
   e.protocol = 17;
   e.pid = pid;
@@ -106,6 +101,6 @@ int trace_udp_sendmsg(struct udp_sendmsg_args *ctx) {
   e.sport = sport;
   e.dport = dport;
 
-  bpf_perf_event_output(ctx, &network_events, BPF_F_CURRENT_CPU, &e, sizeof(e));
+  bpf_ringbuf_output(&network_events_rb, &e, sizeof(e), BPF_RB_NO_WAKEUP);
   return 0;
 }

--- a/bpf/kprobe/trace_udp.c
+++ b/bpf/kprobe/trace_udp.c
@@ -50,7 +50,7 @@ int trace_udp_recvmsg(struct udp_recvmsg_args *ctx) {
   e.direction = 0;
   e.protocol = 17;
 
-  bpf_ringbuf_output(&network_events_rb, &e, sizeof(e), BPF_RB_NO_WAKEUP);
+  bpf_ringbuf_output(&network_events_rb, &e, sizeof(e), BPF_RB_FORCE_WAKEUP);
   return 0;
 }
 
@@ -101,6 +101,6 @@ int trace_udp_sendmsg(struct udp_sendmsg_args *ctx) {
   e.sport = sport;
   e.dport = dport;
 
-  bpf_ringbuf_output(&network_events_rb, &e, sizeof(e), BPF_RB_NO_WAKEUP);
+  bpf_ringbuf_output(&network_events_rb, &e, sizeof(e), BPF_RB_FORCE_WAKEUP);
   return 0;
 }

--- a/bpf/tracepoint/trace_syscall.c
+++ b/bpf/tracepoint/trace_syscall.c
@@ -20,16 +20,14 @@ int tracepoint_sys_enter(struct syscall_trace_enter_args *ctx) {
   }
   
   u32 pid = bpf_get_current_pid_tgid() >> 32;
-  u64 ts = bpf_ktime_get_ns();
   u64 cgroup_id = bpf_get_current_cgroup_id();
 
   struct syscall_event syscall_event = {
     .syscall_nr = ctx->syscall_nr,
-    .ts = ts,
     .cgroup_id = cgroup_id,
     .pid = pid
   };
 
-  bpf_perf_event_output(ctx, &syscall_events, BPF_F_CURRENT_CPU, &syscall_event, sizeof(syscall_event));
+  bpf_ringbuf_output(&network_events_rb, &syscall_event, sizeof(syscall_event), BPF_RB_NO_WAKEUP);
   return 0;
 }

--- a/bpf/tracepoint/trace_syscall.c
+++ b/bpf/tracepoint/trace_syscall.c
@@ -28,6 +28,6 @@ int tracepoint_sys_enter(struct syscall_trace_enter_args *ctx) {
     .pid = pid
   };
 
-  bpf_ringbuf_output(&network_events_rb, &syscall_event, sizeof(syscall_event), BPF_RB_NO_WAKEUP);
+  bpf_ringbuf_output(&syscall_events_rb, &syscall_event, sizeof(syscall_event), BPF_RB_FORCE_WAKEUP);
   return 0;
 }

--- a/cmd/bpfsnitch/main.go
+++ b/cmd/bpfsnitch/main.go
@@ -1,13 +1,17 @@
 package main
 
 import (
-	"log"
+	"os"
 
 	"github.com/nullswan/bpfsnitch/internal/app"
+	"github.com/nullswan/bpfsnitch/internal/logger"
 )
 
 func main() {
-	if err := app.Run(); err != nil {
-		log.Fatal(err)
+	log := logger.Init()
+
+	if err := app.Run(log); err != nil {
+		log.With("error", err).Error("Failed to run app")
+		os.Exit(1)
 	}
 }

--- a/internal/bpf/event.go
+++ b/internal/bpf/event.go
@@ -8,7 +8,6 @@ type Event interface {
 
 type SyscallEvent struct {
 	SyscallNr int64
-	Ts        uint64
 	CgroupID  uint64
 	Pid       uint64
 }
@@ -18,7 +17,6 @@ func (s SyscallEvent) GetSyscallName() string {
 }
 
 type NetworkEvent struct {
-	Ts       uint64
 	Pid      uint64
 	CgroupID uint64
 	Size     uint64

--- a/internal/kernel/version.go
+++ b/internal/kernel/version.go
@@ -1,6 +1,7 @@
 package kernel
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -11,7 +12,7 @@ import (
 func GetKernelVersion() (string, error) {
 	data, err := os.ReadFile("/proc/sys/kernel/osrelease")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to read kernel version: %w", err)
 	}
 	version := strings.TrimSpace(string(data))
 	return version, nil

--- a/internal/kernel/version.go
+++ b/internal/kernel/version.go
@@ -1,0 +1,63 @@
+package kernel
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// GetKernelVersion fetches the Linux kernel version without using exec commands.
+// It reads the version directly from /proc/sys/kernel/osrelease.
+func GetKernelVersion() (string, error) {
+	data, err := os.ReadFile("/proc/sys/kernel/osrelease")
+	if err != nil {
+		return "", err
+	}
+	version := strings.TrimSpace(string(data))
+	return version, nil
+}
+
+// CompareVersions compares two kernel version strings.
+// It returns 1 if v1 > v2, -1 if v1 < v2, and 0 if they are equal.
+func CompareVersions(v1, v2 string) int {
+	v1Parts := strings.Split(v1, ".")
+	v2Parts := strings.Split(v2, ".")
+
+	maxLen := len(v1Parts)
+	if len(v2Parts) > maxLen {
+		maxLen = len(v2Parts)
+	}
+
+	for i := 0; i < maxLen; i++ {
+		var v1Num, v2Num int
+
+		if i < len(v1Parts) {
+			v1Num = extractLeadingNumber(v1Parts[i])
+		}
+		if i < len(v2Parts) {
+			v2Num = extractLeadingNumber(v2Parts[i])
+		}
+
+		if v1Num > v2Num {
+			return 1
+		} else if v1Num < v2Num {
+			return -1
+		}
+	}
+	return 0
+}
+
+// extractLeadingNumber extracts the leading numeric part of a version string segment.
+func extractLeadingNumber(s string) int {
+	numStr := strings.TrimLeftFunc(s, func(r rune) bool {
+		return r < '0' || r > '9'
+	})
+	numStr = strings.TrimRightFunc(numStr, func(r rune) bool {
+		return r < '0' || r > '9'
+	})
+	num, err := strconv.Atoi(numStr)
+	if err != nil {
+		return 0
+	}
+	return num
+}

--- a/internal/sig/handler.go
+++ b/internal/sig/handler.go
@@ -29,8 +29,8 @@ func SetupHandler(
 			kp.Close()
 		}
 
-		bpfCtx.SyscallEventReader.Close()
-		bpfCtx.NetworkEventReader.Close()
+		bpfCtx.SyscallRingBuffer.Close()
+		bpfCtx.NetworkRingBuffer.Close()
 
 		log.Info("Closed event reader")
 	}()


### PR DESCRIPTION
This merge request improves internal event handling by replacing perf event arrays with a ring buffer, aiming for better performance and scalability. The required kernel version is now 5.8 or higher. It also adds a kernel version check and a high-level logger.